### PR TITLE
Convert dementia from Boolean to string

### DIFF
--- a/reference_definitions_schemas/clinicalData.json
+++ b/reference_definitions_schemas/clinicalData.json
@@ -199,7 +199,39 @@
     },
     "dementia": {
       "description": "Is dementia present",
-      "type": "boolean"
+      "type": "string",
+      "anyOf": [
+        {
+          "const": "true",
+          "description": "Dementia is present",
+          "source": ""
+        },
+        {
+          "const": "True",
+          "description": "Dementia is present",
+          "source": ""
+        },
+        {
+          "const": "TRUE",
+          "description": "Dementia is present",
+          "source": ""
+        },
+        {
+          "const": "false",
+          "description": "Dementia is not present",
+          "source": ""
+        },
+        {
+          "const": "False",
+          "description": "Dementia is not present",
+          "source": ""
+        },
+        {
+          "const": "FALSE",
+          "description": "Dementia is not present",
+          "source": ""
+        }
+      ]
     },
     "diagnosisPhenotype": {
       "description": "Diagnosis phenotype",


### PR DESCRIPTION
dementia was originally defined as a Boolean, but this means that it will fail the dccvalidator if the value gets converted to upper case.  Change the typing to string so that values with different cases can be handled.