### PR TITLE
I to l

### DIFF
--- a/reference_definitions_schemas/PEC_specific.json
+++ b/reference_definitions_schemas/PEC_specific.json
@@ -142,7 +142,7 @@
           "const": "3Dchromatin"
         },
         {
-          "const": "ASD-MSSM-IncRNA"
+          "const": "ASD-MSSM-lncRNA"
         },
         {
           "const": "BipSeq"
@@ -181,7 +181,7 @@
           "const": "HumanFC"
         },
         {
-          "const": "IncRNA Pilot"
+          "const": "lncRNA Pilot"
         },
         {
           "const": "iPSC"


### PR DESCRIPTION
When reading the PEC studies from Synapse, I mistook the lowercase "ell" for an uppercase "eye" because of the font that Synapse uses.