### PR TITLE
Use lowercase for AD schemas

### DIFF
--- a/AD/biospecimen_metadata_template.json
+++ b/AD/biospecimen_metadata_template.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id":"sysbio.metadataTemplates-AD.biospecimen",
+    "$id":"sysbio.metadataTemplates-ad.biospecimen",
     "description": "SysBio AD biospecimen metadata template schema",
     "properties": {
         "individualID": {

--- a/AD/manifest_metadata_template.json
+++ b/AD/manifest_metadata_template.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id":"sysbio.metadataTemplates-AD.manifest",
+    "$id":"sysbio.metadataTemplates-ad.manifest",
     "description": "AD manifest template schema",
     "properties": {
         "path": {


### PR DESCRIPTION
Fixes #83. Use lowercase 'ad' when naming AD schemas.