### PR TITLE
Corrected schema ID from rnaSeq to rnaArray

### DIFF
--- a/shared/assay_rnaArray_metadata_template.json
+++ b/shared/assay_rnaArray_metadata_template.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id":"sysbio.metadataTemplates-assay.rnaSeq",
-    "description": "SysBio rnaSeq metadata template schema",
+    "$id":"sysbio.metadataTemplates-assay.rnaArray",
+    "description": "SysBio rnaArray metadata template schema",
     "properties": {
         "specimenID": {
             "$ref": "sage.annotations-experimentalData.specimenID"


### PR DESCRIPTION
Noticed when I was going through the schemas that the ID for this schema said "rnaSeq" instead of "rnaArray".