### PR TITLE
remove cell hashing terms

### DIFF
--- a/shared/assay_rnaSeq_metadata_template.json
+++ b/shared/assay_rnaSeq_metadata_template.json
@@ -15,9 +15,6 @@
         "platform": {
             "$ref": "sage.annotations-experimentalData.platform"
         },
-        "sampleBarcode": {
-            "$ref": "sage.annotations-ngs.sampleBarcode"
-        },
         "RIN": {
             "$ref": "sage.annotations-qc.RIN"
         },
@@ -41,9 +38,6 @@
         },
         "libraryVersion": {
             "$ref": "sage.annotations-ngs.libraryVersion"
-        },
-        "libraryType": {
-            "$ref": "sage.annotations-ngs.libraryType"
         },
         "isStranded": {
             "$ref": "sage.annotations-ngs.isStranded"


### PR DESCRIPTION
I think for AD it makes the most sense to keep the cell hashing terms libraryType and sampleBarcode in the scrnaSeq template, but not in the bulk rnaSeq template. Since we already have separate templates for the two, I don't want to confuse anyone already using the bulk rnaSeq template.