### PR TITLE
Add methylationArray template to PEC

### DIFF
--- a/config/schemas.yml
+++ b/config/schemas.yml
@@ -41,6 +41,7 @@ sysbio.metadataTemplates-assay.metabolomics:
 sysbio.metadataTemplates-assay.methylationArray:
         schema_name: "template_assay_methylationArray.xlsx"
         AD: "syn18512044"
+        PsychENCODE: "syn20729790"
 
 sysbio.metadataTemplates-assay.nanostring:
         schema_name: "template_assay_nanostring.xlsx"
@@ -102,3 +103,4 @@ sysbio.metadataTemplates-pec.individual.human:
 sysbio.metadataTemplates-pec.manifest:
         schema_name: "template_manifest.xlsx"
         PsychENCODE: "syn20729790"
+        


### PR DESCRIPTION
I am trying to follow Cindy's instructions to update our PEC Annotations table so that `dccvalidator` is functional when our new templates our used. Currently, it will fail because some of the terms are not available in the table. 

I still need to add reference to the immunoassay template. @avanlinden or @Aryllen, where are Synapse schemas stored? Would there be on for this assay since I pulled the template directly from AD? 

@pitviper6 fyi, if someone is trying to validate methylationArray or immunoassay, it will fail I think.