### PR TITLE
Add missing AD assay templates

### DIFF
--- a/shared/assay_MRI_metadata_template.json
+++ b/shared/assay_MRI_metadata_template.json
@@ -1,0 +1,34 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id":"sysbio.metadataTemplates-assay.MRI",
+    "description": "SysBio MRI metadata template schema",
+    "properties": {
+        "individualID": {
+            "$ref": "sage.annotations-experimentalData.individualID"
+        },
+        "scanID": {
+            "$ref": "sage.annotations-experimentalData.scanID"
+        },
+        "platform": {
+          "$ref": "sage.annotations-experimentalData.platform"
+        },
+        "MRItype": {
+          "$ref": "sage.annotations-experimentalData.MRItype"
+        },
+        "fieldStrength": {
+          "$ref": "sage.annotations-experimentalData.fieldStrength"
+        },
+        "filename": {
+          "$ref": "sage.annotations-experimentalData.filename"
+        },
+        "contrastAgent": {
+          "$ref": "sage.annotations-experimentalData.contrastAgent"
+        },
+        "ageAssessment": {
+          "$ref": "sage.annotations-experimentalData.ageAssessment"
+        },
+        "ageAssessmentUnits": {
+          "$ref": "sage.annotations-experimentalData.ageAssessmentUnits"
+        }
+    }
+}

--- a/shared/assay_PET_metadata_template.json
+++ b/shared/assay_PET_metadata_template.json
@@ -1,0 +1,28 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id":"sysbio.metadataTemplates-assay.PET",
+    "description": "SysBio PET metadata template schema",
+    "properties": {
+        "individualID": {
+            "$ref": "sage.annotations-experimentalData.individualID"
+        },
+        "scanID": {
+            "$ref": "sage.annotations-experimentalData.scanID"
+        },
+        "ligand": {
+          "$ref": "sage.annotations-experimentalData.ligand"
+        },
+        "filename": {
+          "$ref": "sage.annotations-experimentalData.filename"
+        },
+        "platform": {
+          "$ref": "sage.annotations-experimentalData.platform"
+        },
+        "ageAssessment": {
+          "$ref": "sage.annotations-experimentalData.ageAssessment"
+        },
+        "ageAssessmentUnits": {
+          "$ref": "sage.annotations-experimentalData.ageAssessmentUnits"
+        }
+    }
+}

--- a/shared/assay_autorad_metadata_template.json
+++ b/shared/assay_autorad_metadata_template.json
@@ -1,0 +1,25 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id":"sysbio.metadataTemplates-assay.autorad",
+    "description": "SysBio autoradiography metadata template schema",
+    "properties": {
+        "individualID": {
+            "$ref": "sage.annotations-experimentalData.individualID"
+        },
+        "scanID": {
+            "$ref": "sage.annotations-experimentalData.scanID"
+        },
+        "filename": {
+          "$ref": "sage.annotations-experimentalData.filename"
+        },
+        "platform": {
+          "$ref": "sage.annotations-experimentalData.platform"
+        },
+        "ageAssessment": {
+          "$ref": "sage.annotations-experimentalData.ageAssessment"
+        },
+        "ageAssessmentUnits": {
+          "$ref": "sage.annotations-experimentalData.ageAssessmentUnits"
+        }
+    }
+}


### PR DESCRIPTION
Created JSON schemas for the following AD templates:

- autorad
- MRI
- PET

Keys from these templates are in the process of being added to synapseAnnotations: https://github.com/Sage-Bionetworks/synapseAnnotations/pull/823

They have not been added to DCC validator yet. Setting this up as a draft PR until the new terms are merged into synAnn. 