### PR TITLE
Fix filename module

### DIFF
--- a/shared/assay_MRI_metadata_template.json
+++ b/shared/assay_MRI_metadata_template.json
@@ -19,7 +19,7 @@
           "$ref": "sage.annotations-experimentalData.fieldStrength"
         },
         "filename": {
-          "$ref": "sage.annotations-experimentalData.filename"
+          "$ref": "sage.annotations-manifestKeys.filename"
         },
         "contrastAgent": {
           "$ref": "sage.annotations-experimentalData.contrastAgent"

--- a/shared/assay_PET_metadata_template.json
+++ b/shared/assay_PET_metadata_template.json
@@ -13,7 +13,7 @@
           "$ref": "sage.annotations-experimentalData.ligand"
         },
         "filename": {
-          "$ref": "sage.annotations-experimentalData.filename"
+          "$ref": "sage.annotations-manifestKeys.filename"
         },
         "platform": {
           "$ref": "sage.annotations-experimentalData.platform"

--- a/shared/assay_autorad_metadata_template.json
+++ b/shared/assay_autorad_metadata_template.json
@@ -10,7 +10,7 @@
             "$ref": "sage.annotations-experimentalData.scanID"
         },
         "filename": {
-          "$ref": "sage.annotations-experimentalData.filename"
+          "$ref": "sage.annotations-manifestKeys.filename"
         },
         "platform": {
           "$ref": "sage.annotations-experimentalData.platform"


### PR DESCRIPTION
I forgot that we moved the "filename" term to the manifestKeys module in synapseAnnotations. The three assay templates that use this term (MRI, PET, autorad) have been updated to reference the correct module. 