### PR TITLE
schematize in vitro biospecimen template

### DIFF
--- a/AD/biospecimen_metadata_template.json
+++ b/AD/biospecimen_metadata_template.json
@@ -15,12 +15,6 @@
         "organ": {
             "$ref": "sage.annotations-experimentalData.organ"
         },
-        "organWeight": {
-            "$ref": "sage.annotations-experimentalData.organWeight"
-        },
-        "organRIN": {
-            "$ref": "sage.annotations-qc.organRIN"
-        },
         "tissue": {
             "$ref": "sage.annotations-experimentalData.tissue"
         },
@@ -36,17 +30,11 @@
         "cellType": {
             "$ref": "sage.annotations-experimentalData.cellType"
         },
-        "reprogrammedCellType": {
-            "$ref": "sage.annotations-experimentalData.reprogrammedCellType"
-        },
-        "terminalDifferentiationPoint": {
-            "$ref": "sage.annotations-experimentalData.terminalDifferentiationPoint"
-        },
-        "passage": {
-            "$ref": "sage.annotations-experimentalData.passage"
-        },
         "samplingAge": {
             "$ref": "sage.annotations-experimentalData.samplingAge"
+        },
+        "samplingAgeUnits": {
+            "$ref": "sage.annotations-experimentalData.samplingAgeUnits"
         },
         "sampleStatus": {
             "$ref": "sage.annotations-experimentalData.sampleStatus"

--- a/AD/invitro_biospecimen_metadata_template.json
+++ b/AD/invitro_biospecimen_metadata_template.json
@@ -1,0 +1,52 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id":"sysbio.metadataTemplates-ad.invitroBiospecimen",
+    "description": "SysBio AD in vitro biospecimen metadata template schema",
+    "properties": {
+        "individualID": {
+            "$ref": "sage.annotations-experimentalData.individualID"
+        },
+        "specimenID": {
+            "$ref": "sage.annotations-experimentalData.specimenID"
+        },
+        "specimenIdSource": {
+            "$ref": "sage.annotations-experimentalData.specimenIdSource"
+        },
+        "modelSystemType": {
+          "$ref": "sage.annotations-experimentalData.modelSystemType"
+        },
+        "sourceCell": {
+          "$ref": "sage.annotations-experimentalData.sourceCell"
+        },
+        "cellType": {
+            "$ref": "sage.annotations-experimentalData.cellType"
+        },
+        "reprogrammingMethod": {
+          "$ref": "sage.annotations-experimentalData.reprogrammingMethod"
+        },
+        "differentiationMethod": {
+          "$ref": "sage.annotations-experimentalData.differentiationMethod"
+        },
+        "passage": {
+            "$ref": "sage.annotations-experimentalData.passage"
+        },
+        "terminalDifferentiationPoint": {
+            "$ref": "sage.annotations-experimentalData.terminalDifferentiationPoint"
+        },
+        "samplingAge": {
+            "$ref": "sage.annotations-experimentalData.samplingAge"
+        },
+        "samplingAgeUnits": {
+            "$ref": "sage.annotations-experimentalData.samplingAgeUnits"
+        },
+        "treatmentType": {
+            "$ref": "sage.annotations-neuro.treatmentType"
+        },
+        "nucleicAcidSource": {
+            "$ref": "sage.annotations-ngs.nucleicAcidSource"
+        },
+        "assay": {
+            "$ref": "sage.annotations-experimentalData.assay"
+        }
+    }
+}


### PR DESCRIPTION
This creates the JSON schema for the new AD in vitro biospecimen template. This PR is a draft until the new terms are merged into synapseAnnotations.

https://github.com/Sage-Bionetworks/synapseAnnotations/pull/841