### PR TITLE
Update invitro biospecimen name and location; add to config

### DIFF
--- a/config/schemas.yml
+++ b/config/schemas.yml
@@ -99,6 +99,11 @@ sysbio.metadataTemplates-biospecimen.drosophila:
         schema_name: "template_biospecimen_drosophila.xlsx"
         AD: "syn18512044"
 
+sysbio.metadataTemplates-biospecimen.invitro:
+        schema_name: "template_biospecimen_invitro.xlsx"
+        AD: "syn18512044"
+        PEC: "syn20729790"
+
 sysbio.metadataTemplates-individual.animal:
         schema_name: "template_individual_animal.xlsx"
         AD: "syn18512044"

--- a/schema_metadata_templates/shared/biospecimen_invitro_metadata_template.json
+++ b/schema_metadata_templates/shared/biospecimen_invitro_metadata_template.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id":"sysbio.metadataTemplates-invitro.biospecimen",
+    "$id":"sysbio.metadataTemplates-biospecimen.invitro",
     "description": "SysBio in vitro biospecimen metadata template schema",
     "properties": {
         "individualID": {

--- a/schema_metadata_templates/shared/invitro_biospecimen_metadata_template.json
+++ b/schema_metadata_templates/shared/invitro_biospecimen_metadata_template.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id":"sysbio.metadataTemplates-ad.invitroBiospecimen",
-    "description": "SysBio AD in vitro biospecimen metadata template schema",
+    "$id":"sysbio.metadataTemplates-invitro.biospecimen",
+    "description": "SysBio in vitro biospecimen metadata template schema",
     "properties": {
         "individualID": {
             "$ref": "sage.annotations-experimentalData.individualID"


### PR DESCRIPTION
- AD and PEC are using the same template so moved to 'shared' folder
- Renamed to remove AD specificity and to group next to biospecimen (i.e. changed from invitroBiospecimen to biospecimen.invitro).
- Added template to config