### PR TITLE
Spell out 16 in 16SrRNAseq template

### DIFF
--- a/config/schemas.yml
+++ b/config/schemas.yml
@@ -10,7 +10,7 @@ sysbio.metadataTemplates-ad.manifest:
         schema_name: "template_manifest.xlsx"
         AD: "syn18512044"
 
-sysbio.metadataTemplates-assay.16SrRNAseq:
+sysbio.metadataTemplates-assay.sixteenSrRNAseq:
         schema_name: "template_assay_16SrRNAseq.xlsx"
         AD: "syn18512044"
 

--- a/schema_metadata_templates/shared/assay_16SrRNAseq_metadata_template.json
+++ b/schema_metadata_templates/shared/assay_16SrRNAseq_metadata_template.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id":"sysbio.metadataTemplates-assay.16SrRNAseq",
+    "$id":"sysbio.metadataTemplates-assay.sixteenSrRNAseq",
     "description": "SysBio 16SrRNAseq metadata template schema",
     "properties": {
         "specimenID": {


### PR DESCRIPTION
Fix 16SrRNAseq template. Schemas cannot not start with numbers even after periods.