### PR TITLE
correct the synID for modelad.individual.animal 

### DIFF
--- a/config/schemas.yml
+++ b/config/schemas.yml
@@ -127,5 +127,5 @@ sysbio.metadataTemplates-pec.manifest:
         
 sysbio.metadataTemplates-modelad.individual.animal:
         schema_name: "template_individual_animal_model-ad.xlsx"
-        AD: "syn21084071"
+        AD: "syn18512044"
         


### PR DESCRIPTION
Use the synID of template folder for modelad.individual.animal since this specified the targeted output folder for the template.